### PR TITLE
Update schain path in ORTB request body for spotxBidAdapter

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -227,7 +227,7 @@ export const spec = {
 
       // Add schain object if it is present
       if (bid && bid.schain) {
-        requestPayload['ext']['source'] = {
+        requestPayload['source'] = {
           ext: {
             schain: bid.schain
           }

--- a/test/spec/modules/spotxBidAdapter_spec.js
+++ b/test/spec/modules/spotxBidAdapter_spec.js
@@ -183,21 +183,7 @@ describe('the spotx adapter', function () {
       expect(request.data.imp.bidfloor).to.equal(123);
       expect(request.data.ext).to.deep.equal({
         number_of_ads: 2,
-        wrap_response: 1,
-        source: {
-          ext: {
-            schain: {
-              complete: 1,
-              nodes: [
-                {
-                  asi: 'indirectseller.com',
-                  sid: '00001',
-                  hp: 1
-                }
-              ]
-            }
-          }
-        }
+        wrap_response: 1
       });
       expect(request.data.user.ext).to.deep.equal({
         consented_providers_settings: GOOGLE_CONSENT,
@@ -208,6 +194,21 @@ describe('the spotx adapter', function () {
           }]
         }],
         fpc: 'pubcid_1'
+      })
+
+      expect(request.data.source).to.deep.equal({
+        ext: {
+          schain: {
+            complete: 1,
+            nodes: [
+              {
+                asi: 'indirectseller.com',
+                sid: '00001',
+                hp: 1
+              }
+            ]
+          }
+        }
       })
     });
 


### PR DESCRIPTION
	- Move schain object from request.ext.source.ext.schain to
	  request.source.ext.schain

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Move schain object from "request.ext.source.ext.schain" to "request.source.ext.schain"
